### PR TITLE
Format visualize_crossover.jl and parallel_evaluator.jl with Runic

### DIFF
--- a/examples/visualize_crossover.jl
+++ b/examples/visualize_crossover.jl
@@ -17,12 +17,12 @@ function plot_crossover(
     children_mtx = hcat(
         [
             hcat(
-                    apply!(
-                        xover, [fill!(Individual(undef, size(parents, 1)), NaN) for _ in 1:numchildren(xover)],
-                        zeros(Int, numchildren(xover)), parents_pop,
-                        shuffle_parents ? shuffle(parent_ixs) : parent_ixs
-                    )...
-                ) for _ in 1:n
+                apply!(
+                    xover, [fill!(Individual(undef, size(parents, 1)), NaN) for _ in 1:numchildren(xover)],
+                    zeros(Int, numchildren(xover)), parents_pop,
+                    shuffle_parents ? shuffle(parent_ixs) : parent_ixs
+                )...
+            ) for _ in 1:n
         ]...
     )
     plot(

--- a/src/parallel_evaluator.jl
+++ b/src/parallel_evaluator.jl
@@ -134,13 +134,13 @@ function ParallelEvaluator(
         0, nafitness(fs), nafitness(FA),
         [
             RemoteChannel(
-                    function ()
-                        # create fake channel and put problem there
-                        ch = Channel{ParallelEvaluatorWorker{P}}(1)
-                        put!(ch, ParallelEvaluatorWorker(copy(problem)))
-                        return ch
+                function ()
+                    # create fake channel and put problem there
+                    ch = Channel{ParallelEvaluatorWorker{P}}(1)
+                    put!(ch, ParallelEvaluatorWorker(copy(problem)))
+                    return ch
                 end, pid
-                ) for pid in pids
+            ) for pid in pids
         ],
         ParallelEvaluationState(archive, length(pids))
     )


### PR DESCRIPTION
## Summary

`Format Check` on master fails on two files: `examples/visualize_crossover.jl` and `src/parallel_evaluator.jl` (indentation drift inside nested `apply!`/`RemoteChannel` calls). This applies `Runic.format_file` to exactly those files; the remaining 148 checked files are clean.

## Test plan

- [x] Local `Runic.format_file` produces exactly the diff CI's format check reports

🤖 Generated with [Devin](https://devin.ai) — Agent-Harness: Devin CLI 3000.10.21, Agent-Model: SWE-2 Max, Agent-Session: /home/crackauc/.local/share/devin/cli/summaries/history_4c9fddb81d834736.md (local session transcript; no shareable URL)